### PR TITLE
feat: add varnish-dev removed from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y \
 	libtool \
 	automake \
 	autoconf-archive \
-	python3-docutils
+	python3-docutils \
+	&& dpkg -i /pkgs/*varnish-dev*.deb || apt-get -f install -y
 
 WORKDIR /
 COPY . .

--- a/debug/Dockerfile
+++ b/debug/Dockerfile
@@ -1,4 +1,4 @@
-FROM varnish:7.7.1
+FROM varnish:7.7.3
 
 USER root
 
@@ -11,7 +11,8 @@ RUN apt-get update && \
     autoconf-archive \
     libasan8 \
     gdb \
-    procps
+    procps \
+    && dpkg -i /pkgs/*varnish-dev*.deb || apt-get -f install -y
 
 WORKDIR /
 


### PR DESCRIPTION
- `varnish-dev` was removed here, creating issues with the build. Reinstall so that Dockerfile builds work again: https://github.com/varnish/docker-varnish/commit/7489d188a63e4b649b3d57ff9fe50acea1de4c7f
- Upgrade to Varnish 7.7.3 in debug Dockerfile